### PR TITLE
Github action to publish the package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,48 @@
+name: Publish
+on: 
+  push:
+    tags:
+      # This is triggered when new tag starting with v is pushed to the repository.
+      - v**
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v3
+
+      - name: Read the tag name
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - uses: actions/setup-node@v3
+        with:
+           node-version: 16.x
+           cache: 'yarn'
+
+      - name: Set package version from git tag
+        run: | 
+          GIT_TAG=${{  github.ref_name }}
+          VERSION="${GIT_TAG#v}"
+          yarn workspace sql-language-server version --new-version ${VERSION} --no-git-tag-version
+
+      - run: yarn install
+      - run: yarn npm:prepublish
+
+      # We rename the package dynamically to include the @deepnote namespace 
+      # in the build script instead of renaming it in the package.json
+      # because other packages depend on it and we want to keep the name the same for tests to pass.
+      - name: Rename the package
+        run: npm pkg set name=@deepnote/sql-language-server --workspace packages/server
+        
+      - name: Configure github packages npm repository
+        run: | 
+           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+           echo "@deepnote:registry=https://npm.pkg.github.com" >> ~/.npmrc
+
+      # We use `npm publish` instead of `yarn publish` because yarn publish
+      # checks if the repository is clean and fails if it's not. This is complicated for us, given we rename 
+      # the pacakge dynamically and we don't want to commit the changes to the package.json.
+      - name: Publish the server package
+        run: |
+          npm publish --workspace packages/server


### PR DESCRIPTION
This adds new github action "publish", which is triggered any time tag starting with `v` (for example `v1.3.5`) is pushed.

The action then builds and publishes version according to the tag name. So for example for tag `v1.3.5`, this action will publish `1.3.5`. The workflow expects the tag to follow semantic versioning -- internally it uses [`yarn version`](https://classic.yarnpkg.com/en/docs/cli/version) (from yarn classic -- because it is used by the upstream) and it fails on invalid / non-semantic versions.

Given this is triggered by tag, the workflow does not push back the altered `package.json` with the bumped version.

The package is pushed to [GitHub package registry in this repository](https://github.com/deepnote/sql-language-server/pkgs/npm/sql-language-server).