### PR TITLE
Add support for parsing database entities including hyphens

### DIFF
--- a/packages/server/src/complete/utils/getLastToken.ts
+++ b/packages/server/src/complete/utils/getLastToken.ts
@@ -1,6 +1,6 @@
-// Gets the last token from the given string considering that tokens can contain dots.
+// Gets the last token from the given string considering that tokens can contain dots and dashes.
 export function getLastToken(sql: string): string {
-  const match = sql.match(/^(?:.|\s)*[^A-z0-9\\.:'"](.*?)$/)
+  const match = sql.match(/^(?:.|\s)*[^A-z0-9\\.\-:'"](.*?)$/)
   if (match) {
     let prevToken = ''
     let currentToken = match[1]

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -999,3 +999,47 @@ describe('DROP statement', () => {
     expect(result.candidates[0].label).toEqual('TABLE1')
   })
 })
+
+const SIMPLE_NESTED_SCHEMA_WITH_HYPHEN = {
+  tables: [
+    {
+      catalog: 'catalog-3',
+      database: 'schema3',
+      tableName: 'table3',
+      columns: [{ columnName: 'abc', description: 'def' }],
+    },
+  ],
+  functions: [],
+}
+
+describe('Fully qualified table names with dash', () => {
+  test('complete catalog name', () => {
+    const result = complete(
+      'SELECT * FROM catalog-3.sch',
+      { line: 0, column: 26 },
+      SIMPLE_NESTED_SCHEMA_WITH_HYPHEN
+    )
+    expect(result.candidates.length).toEqual(1)
+    const expected = [expect.objectContaining({ label: 'schema3' })]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+  test('complete table name', () => {
+    const result = complete(
+      'SELECT * FROM catalog-3.schema3.tab',
+      { line: 0, column: 34 },
+      SIMPLE_NESTED_SCHEMA_WITH_HYPHEN
+    )
+    expect(result.candidates.length).toEqual(1)
+    const expected = [expect.objectContaining({ label: 'table3' })]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+  test('complete table name on dot', () => {
+    const result = complete(
+      'SELECT * FROM catalog-3.schema3.',
+      { line: 0, column: 32 },
+      SIMPLE_NESTED_SCHEMA_WITH_HYPHEN
+    )
+    const expected = [expect.objectContaining({ label: 'table3' })]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+})

--- a/packages/sql-parser/base/fromClauseParser.js
+++ b/packages/sql-parser/base/fromClauseParser.js
@@ -327,7 +327,7 @@ function peg$parse(input, options) {
   var peg$r2 = /^[^"]/;
   var peg$r3 = /^[.]/;
   var peg$r4 = /^[A-Za-z_]/;
-  var peg$r5 = /^[A-Za-z0-9_]/;
+  var peg$r5 = /^[A-Za-z0-9_\-]/;
   var peg$r6 = /^[A-Za-z0-9_:[\]']/;
   var peg$r7 = /^[:@]/;
   var peg$r8 = /^[^'\\\0-\x1F\x7F]/;
@@ -364,7 +364,7 @@ function peg$parse(input, options) {
   var peg$e21 = peg$classExpectation(["\""], true, false);
   var peg$e22 = peg$classExpectation(["."], false, false);
   var peg$e23 = peg$classExpectation([["A", "Z"], ["a", "z"], "_"], false, false);
-  var peg$e24 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_"], false, false);
+  var peg$e24 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", "-"], false, false);
   var peg$e25 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", ":", "[", "]", "'"], false, false);
   var peg$e26 = peg$classExpectation([":", "@"], false, false);
   var peg$e27 = peg$literalExpectation("\"", false);

--- a/packages/sql-parser/base/parser.js
+++ b/packages/sql-parser/base/parser.js
@@ -327,7 +327,7 @@ function peg$parse(input, options) {
   var peg$r2 = /^[^"]/;
   var peg$r3 = /^[.]/;
   var peg$r4 = /^[A-Za-z_]/;
-  var peg$r5 = /^[A-Za-z0-9_]/;
+  var peg$r5 = /^[A-Za-z0-9_\-]/;
   var peg$r6 = /^[A-Za-z0-9_:[\]']/;
   var peg$r7 = /^[:@]/;
   var peg$r8 = /^[^'\\\0-\x1F\x7F]/;
@@ -364,7 +364,7 @@ function peg$parse(input, options) {
   var peg$e21 = peg$classExpectation(["\""], true, false);
   var peg$e22 = peg$classExpectation(["."], false, false);
   var peg$e23 = peg$classExpectation([["A", "Z"], ["a", "z"], "_"], false, false);
-  var peg$e24 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_"], false, false);
+  var peg$e24 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", "-"], false, false);
   var peg$e25 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", ":", "[", "]", "'"], false, false);
   var peg$e26 = peg$classExpectation([":", "@"], false, false);
   var peg$e27 = peg$literalExpectation("\"", false);

--- a/packages/sql-parser/parser.pegjs
+++ b/packages/sql-parser/parser.pegjs
@@ -843,7 +843,7 @@ ident_name
 
 ident_start = [A-Za-z_]
 
-ident_part  = [A-Za-z0-9_]
+ident_part  = [A-Za-z0-9_-]
 
 // to support column name like `cf1:name` in hbase
 // Allow square brackets and quote to support nested columns with subscripts for example `books['title'].chapters[12].paragraphs`


### PR DESCRIPTION
🎉 

How did I do it:
1. Adding a hyphen to `getLastToken` is obvious
2. I pasted the parse.pegjs file into ChatGPT and asked where I should add support for entities containing a hyphen
3. ChatGPT pointed me towards ident_part
4. I regenerated the parser with `npm build`