### PR TITLE
Change package/server dependancy to local sql-parser

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@google-cloud/bigquery": "^5.9.0",
-    "@joe-re/sql-parser": "^1.7.0",
+    "@joe-re/sql-parser": "file:../sql-parser",
     "@types/pg": "^8.6.6",
     "@types/yargs": "^17.0.8",
     "cardinal": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,6 +618,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@joe-re/sql-parser@file:packages/sql-parser":
+  version "1.7.0"
+  dependencies:
+    peggy "^3.0.2"
+
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"


### PR DESCRIPTION
All the changes I made in #7 were in `packages/sql-parser`. While running the publishing GitHub action  we are building `packages/server`, but it has a dependency on the published `@joe-re/sql-parser` and not the one I modified. ChatGPT advised me that the `packages/server` dependency could be changed to the local `sql-parser` so I modified using "@joe-re/sql-parser": "file:../sql-parser". 

If I'm proceeding correctly, what could be the next steps?
1. This pull request
2. Re-publish the new version of `deepnote/sql-language-server` with the same tag `v1.7.2-deepnote`. ChatGPT advised me that removing and pushing the same tag should overwrite it