### PR TITLE
Publish sql-parser package separately

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,46 +6,6 @@ on:
       - v**
 
 jobs:
-  publish-server:
-    name: Publish Server
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v3
-
-      - name: Read the tag name
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      - uses: actions/setup-node@v3
-        with:
-           node-version: 16.x
-           cache: 'yarn'
-
-      - name: Set package version from git tag
-        run: | 
-          GIT_TAG=${{  github.ref_name }}
-          VERSION="${GIT_TAG#v}"
-          yarn workspace sql-language-server version --new-version ${VERSION} --no-git-tag-version
-
-      - run: yarn install
-      - run: yarn npm:prepublish
-
-      # We rename the package dynamically to include the @deepnote namespace 
-      # in the build script instead of renaming it in the package.json
-      # because other packages depend on it and we want to keep the name the same for tests to pass.
-      - name: Rename the package
-        run: npm pkg set name=@deepnote/sql-language-server --workspace packages/server
-        
-      - name: Configure github packages npm repository
-        run: | 
-           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
-           echo "@deepnote:registry=https://npm.pkg.github.com" >> ~/.npmrc
-
-      # We use `npm publish` instead of `yarn publish` because yarn publish
-      # checks if the repository is clean and fails if it's not. This is complicated for us, given we rename 
-      # the package dynamically and we don't want to commit the changes to the package.json.
-      - name: Publish the server package
-        run: npm publish --workspace packages/server
-
   publish-sql-parser:
     name: Publish SQL Parser
     runs-on: ubuntu-latest
@@ -86,3 +46,44 @@ jobs:
       # the package dynamically and we don't want to commit the changes to the package.json.
       - name: Publish the sql-parser package
         run: npm publish --workspace packages/sql-parser
+
+  publish-server:
+    name: Publish Server
+    runs-on: ubuntu-latest
+    needs: publish-sql-parser
+    steps: 
+      - uses: actions/checkout@v3
+
+      - name: Read the tag name
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - uses: actions/setup-node@v3
+        with:
+           node-version: 16.x
+           cache: 'yarn'
+
+      - name: Set package version from git tag
+        run: | 
+          GIT_TAG=${{  github.ref_name }}
+          VERSION="${GIT_TAG#v}"
+          yarn workspace sql-language-server version --new-version ${VERSION} --no-git-tag-version
+
+      - run: yarn install
+      - run: yarn npm:prepublish
+
+      # We rename the package dynamically to include the @deepnote namespace 
+      # in the build script instead of renaming it in the package.json
+      # because other packages depend on it and we want to keep the name the same for tests to pass.
+      - name: Rename the package
+        run: npm pkg set name=@deepnote/sql-language-server --workspace packages/server
+        
+      - name: Configure github packages npm repository
+        run: | 
+           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+           echo "@deepnote:registry=https://npm.pkg.github.com" >> ~/.npmrc
+
+      # We use `npm publish` instead of `yarn publish` because yarn publish
+      # checks if the repository is clean and fails if it's not. This is complicated for us, given we rename 
+      # the package dynamically and we don't want to commit the changes to the package.json.
+      - name: Publish the server package
+        run: npm publish --workspace packages/server

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,8 @@ on:
       - v**
 
 jobs:
-  publish:
-    name: Publish
+  publish-server:
+    name: Publish Server
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v3
@@ -42,7 +42,47 @@ jobs:
 
       # We use `npm publish` instead of `yarn publish` because yarn publish
       # checks if the repository is clean and fails if it's not. This is complicated for us, given we rename 
-      # the pacakge dynamically and we don't want to commit the changes to the package.json.
+      # the package dynamically and we don't want to commit the changes to the package.json.
       - name: Publish the server package
-        run: |
-          npm publish --workspace packages/server
+        run: npm publish --workspace packages/server
+
+  publish-sql-parser:
+    name: Publish SQL Parser
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v3
+
+      - name: Read the tag name
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - uses: actions/setup-node@v3
+        with:
+           node-version: 16.x
+           cache: 'yarn'
+
+      - name: Set package version from git tag
+        run: | 
+          GIT_TAG=${{  github.ref_name }}
+          VERSION="${GIT_TAG#v}"
+          yarn workspace sql-parser version --new-version ${VERSION} --no-git-tag-version
+
+      - run: yarn install
+      - run: yarn npm:prepublish
+
+      # We rename the package dynamically to include the @deepnote namespace 
+      # in the build script instead of renaming it in the package.json
+      # because other packages depend on it and we want to keep the name the same for tests to pass.
+      - name: Rename the package
+        run: npm pkg set name=@deepnote/sql-parser --workspace packages/sql-parser
+
+      - name: Configure github packages npm repository
+        run: | 
+           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+           echo "@deepnote:registry=https://npm.pkg.github.com" >> ~/.npmrc
+           # We use `npm publish` instead of `yarn publish` because yarn publish
+
+      # We use `npm publish` instead of `yarn publish` because yarn publish
+      # checks if the repository is clean and fails if it's not. This is complicated for us, given we rename 
+      # the package dynamically and we don't want to commit the changes to the package.json.
+      - name: Publish the sql-parser package
+        run: npm publish --workspace packages/sql-parser


### PR DESCRIPTION
Continuation of #8. Unfortunately, pointer to a local package doesn't work. 

This PR updates the GitHub package publishing action, so that it also publishes a new `deepnote/sql-parser` package. A follow-up pull request will be required to update the usage from `@joe-re/sql-parser` to `deepnote/sql-parser`