### PR TITLE
chore: bump packages to 2.0.0

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/sql-language-server",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "main": "dist/src/index.js",
   "bin": {
     "sql-language-server": "./npm_bin/cli.js"
@@ -39,8 +39,9 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@google-cloud/bigquery": "^5.9.0",
     "@deepnote/sql-parser": "^2.0.0",
+    "@deepnote/sqlint": "^2.0.0",
+    "@google-cloud/bigquery": "^5.9.0",
     "@types/pg": "^8.6.6",
     "@types/yargs": "^17.0.8",
     "cardinal": "^2.1.1",
@@ -48,12 +49,11 @@
     "mysql2": "^2.3.0",
     "node-ssh-forward": "^0.6.3",
     "pg": "^8.9.0",
-    "@deepnote/sqlint": "^1.7.0",
     "sqlite3": "^5.0.3",
     "vscode-languageclient": "^6.1.3",
-    "vscode-languageserver": "8.0.0-next.8",
     "vscode-languageserver-protocol": "^3.15.3",
     "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-languageserver": "8.0.0-next.8",
     "yargs": "^17.3.1"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@google-cloud/bigquery": "^5.9.0",
-    "@deepnote/sql-parser": "^1.7.0",
+    "@deepnote/sql-parser": "^2.0.0",
     "@types/pg": "^8.6.6",
     "@types/yargs": "^17.0.8",
     "cardinal": "^2.1.1",

--- a/packages/sql-parser/package.json
+++ b/packages/sql-parser/package.json
@@ -2,7 +2,7 @@
   "author": "joe-re<joe.tialtngo@gmail.com>",
   "name": "@deepnote/sql-parser",
   "description": "sql parser for nodejs",
-  "version": "1.7.5",
+  "version": "2.0.0",
   "typings": "index.d.ts",
   "scripts": {
     "test": "jest",

--- a/packages/sqlint/package.json
+++ b/packages/sqlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/sqlint",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "main": "dist/src/index",
   "bin": "bin/cli.js",
   "author": "joe-re<joe.tialtngo@gmail.com>",

--- a/packages/sqlint/package.json
+++ b/packages/sqlint/package.json
@@ -32,7 +32,7 @@
   ],
   "types": "./dist/src",
   "dependencies": {
-    "@deepnote/sql-parser": "^1.7.0",
+    "@deepnote/sql-parser": "^2.0.0",
     "ajv": "^6.12.2",
     "chalk": "^4.0.0",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released SQL Parser package version 2.0.0.
  * Bumped server and SQL linter components to use SQL Parser 2.0.0 and SQL linter 2.0.0.
  * Updated dependency references to the new 2.0.0 packages.
  * Minor manifest formatting cleanup (added trailing newline).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->