### PR TITLE
fix: autocomplete table names after FROM/JOIN keywords

### DIFF
--- a/packages/server/src/complete/complete.ts
+++ b/packages/server/src/complete/complete.ts
@@ -111,7 +111,7 @@ class Completer {
           // Incomplete sub query 'SELECT sub FROM (SELECT e. FROM employees e) sub'
           this.addCandidatesForIncompleteSubquery(fromNodeOnCursor)
         } else {
-          this.addCandidatesForSelectQuery(e, fromNodes)
+          this.addCandidatesForSelectQuery(e, fromNodes, parsedFromClause)
           const expectedLiteralNodes =
             e.expected?.filter(
               (v): v is ExpectedLiteralNode => v.type === 'literal'
@@ -239,7 +239,11 @@ class Completer {
     this.addCandidatesForTables(this.schema.tables, false)
   }
 
-  addCandidatesForSelectQuery(e: ParseError, fromNodes: FromTableNode[]) {
+  addCandidatesForSelectQuery(
+    e: ParseError,
+    fromNodes: FromTableNode[],
+    parsedFromClause: FromClauseParserResult
+  ) {
     const subqueryTables = createTablesFromFromNodes(fromNodes)
     const schemaAndSubqueries = this.schema.tables.concat(subqueryTables)
     this.addCandidatesForSelectStar(fromNodes, schemaAndSubqueries)
@@ -263,8 +267,19 @@ class Completer {
       isPosInLocation(tableNode.location, this.pos)
     )
     const isCursorInsideFromClause = fromNodesContainingCursor.length > 0
-    if (isCursorInsideFromClause) {
-      // only add table candidates if the cursor is inside a FROM clause or JOIN clause, etc.
+
+    // Check if cursor is right after FROM keyword (no table typed yet)
+    const afterFromClause = parsedFromClause.after?.trim().toUpperCase() || ''
+    const isCursorAfterFromKeyword =
+      afterFromClause === 'FROM' ||
+      afterFromClause.startsWith('FROM ') ||
+      /^(INNER |LEFT |RIGHT |FULL |FULL OUTER |CROSS |NATURAL |OUTER )?JOIN( |$)/.test(
+        afterFromClause
+      )
+
+    if (isCursorInsideFromClause || isCursorAfterFromKeyword) {
+      // add table candidates if the cursor is inside a FROM clause, JOIN clause,
+      // or right after FROM/JOIN keyword waiting for a table name
       this.addCandidatesForTables(schemaAndSubqueries, true)
     }
 

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -241,6 +241,24 @@ describe('From clause', () => {
     expect(result.candidates[0].insertText).toEqual('TABLE1')
   })
 
+  test('from clause: complete TableName after FROM keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM ',
+      { line: 0, column: 14 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after FROM keyword with space:multi line', () => {
+    const result = complete(
+      'SELECT *\nFROM ',
+      { line: 1, column: 5 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
   test('from clause: complete TableName:multi lines', () => {
     const result = complete(
       'SELECT TABLE1.COLUMN1\nFROM T',
@@ -276,6 +294,69 @@ describe('From clause', () => {
       SIMPLE_SCHEMA
     )
     expect(result.candidates.map((v) => v.label)).toContain('ON')
+  })
+
+  test('from clause: complete TableName after JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 JOIN ',
+      { line: 0, column: 26 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after INNER JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 INNER JOIN ',
+      { line: 0, column: 32 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after LEFT JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 LEFT JOIN ',
+      { line: 0, column: 31 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after RIGHT JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 RIGHT JOIN ',
+      { line: 0, column: 32 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after CROSS JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 CROSS JOIN ',
+      { line: 0, column: 32 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after FULL OUTER JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 FULL OUTER JOIN ',
+      { line: 0, column: 37 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
+  })
+
+  test('from clause: complete TableName after NATURAL JOIN keyword with space', () => {
+    const result = complete(
+      'SELECT * FROM TABLE1 NATURAL JOIN ',
+      { line: 0, column: 34 },
+      SIMPLE_SCHEMA
+    )
+    expect(result.candidates.map((v) => v.label)).toContain('TABLE1')
   })
 })
 


### PR DESCRIPTION
Table names were not being suggested when the cursor was positioned right after FROM or JOIN keywords with no table typed yet. This adds detection for cursor position after these keywords using the parsed FROM clause's `after` field.

Supports all JOIN types: INNER, LEFT, RIGHT, FULL, FULL OUTER, CROSS, NATURAL, and plain JOIN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SQL editor's table name autocomplete suggestions with improved cursor position detection when working within FROM and JOIN clauses, including detection immediately following FROM/JOIN keywords for more accurate completions during query composition

* **Tests**
  * Added comprehensive test coverage for table name autocompletion scenarios across various FROM and JOIN clause configurations, including different JOIN types, spacing patterns, and multi-line query formatting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->